### PR TITLE
Replace summary in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,18 @@
 # cribl-control-plane-sdk-go
-<!-- Start Summary [summary] -->
-## Summary
 
-Cribl API Reference: This API Reference lists available REST endpoints, along with their supported operations for accessing, creating, updating, or deleting resources. See our complementary product documentation at [docs.cribl.io](http://docs.cribl.io).
-<!-- End Summary [summary] -->
+The Cribl Go SDK for the control plane provides operational control over Cribl resources and helps streamline the process of integrating with Cribl.
+
+In addition to the usage examples in this repository, you can adapt the [code examples for common use cases](http://docs.cribl.io/cribl-as-code/code-examples/)) in the Cribl documentation to use Go instead of Python.
+
+Complementary API reference documentation is available at https://docs.cribl.io/cribl-as-code/api-reference/. Product documentation is available at https://docs.cribl.io.
+
+> [!IMPORTANT]
+> **Preview Feature**
+> The Cribl SDKs are Preview features that are still being developed. We do not recommend using them in a production environment, because the features might not be fully tested or optimized for performance, and related documentation could be incomplete.
+>
+> Please continue to submit feedback through normal Cribl support channels, but assistance might be limited while the features remain in Preview.
+
+<!-- No Summary [summary] -->
 
 <!-- Start Table of Contents [toc] -->
 ## Table of Contents


### PR DESCRIPTION
Replaces the summary content in the README.md file and updates the README.md file so that the summary section is managed manually. The existing summary originates from the OpenAPI spec, which is not tailored to address the SDK use case. The updated summary also includes the boilerplate language that is approved for preview features.

The links to the Cribl as Code docs are speculative until two PRs in the cribl-doc repo are merged:

- https://bitbucket.org/cribl/cribl-doc/pull-requests/5759
- https://bitbucket.org/cribl/cribl-doc/pull-requests/5696